### PR TITLE
strip ansi characters before semver validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 var exec = require('child_process').exec;
 var semverValid = require('semver').valid;
 var regex = /tag:\s*(.+?)[,\)]/gi;
-var cmd = 'git log --decorate';
+var cmd = 'git log --decorate --no-color';
 
 module.exports = function(callback) {
   exec(cmd, {


### PR DESCRIPTION
resolves #4: semverValid returns null if git log outputs ansi characters for colored output.
resolves stevemao/conventional-github-releaser/issues/7
