### PR TITLE
fix: only list decorated commits

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 var exec = require('child_process').exec;
 var semverValid = require('semver').valid;
 var regex = /tag:\s*(.+?)[,\)]/gi;
-var cmd = 'git log --decorate --no-color';
+var cmd = 'git log --author-date-order --tags --decorate --no-color --format=\'%d\'';
 
 module.exports = function(callback) {
   exec(cmd, {


### PR DESCRIPTION
-  Adds `--author-date-order` for intended orderings
-  Adds `--tags` to omit unreferenced commits
-  Adds `--format='%d' to print only decorations
-  Should speed up things considerably
-  Limits risk to match on commit messages

This also fixes a problem with omitted tags in a project of mine. Unfortunately I can not share the affected git history. I'll try to isolate the root cause.

**This becomes obsolete when #6 is merged**
