### PR TITLE
fix: we should still return tags pointing to deleted branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,13 @@
 
 > Get all git semver tags of your repository in reverse chronological order
 
-*Note:* since lightweight tags do not store date information, the date of a tag is the date of the commit that is tagged on. If two tags on one commit, the order is not guaranteed.
+_*Note:* since lightweight tags do not store date information, the date of a tag is the date of the commit that it is tagged on. If two tags are placed on one commit, the order is not guaranteed._
 
+## How it works
+
+_git-semver-tags_ runs `git log --all --date-order` to fetch and parse a reverse-chronological list of
+semver tags. By using `--all`, tags are returned regardless of whether or not the commit they are
+attached to has been squashed.
 
 ## Install
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 var exec = require('child_process').exec;
 var semverValid = require('semver').valid;
 var regex = /tag:\s*(.+?)[,\)]/gi;
-var cmd = 'git log --decorate --no-color';
+var cmd = 'git log --all --date-order --decorate --no-color';
 
 module.exports = function(callback) {
   exec(cmd, {

--- a/test.js
+++ b/test.js
@@ -113,3 +113,18 @@ it('should work with empty commit', function(done) {
     done();
   });
 });
+
+// see: https://github.com/conventional-changelog/standard-version/issues/123
+it('should return tags pointing to squashed branches', function(done) {
+  shell.exec('git checkout -b delete-me');
+  gitDummyCommit('empty commit1');
+  shell.exec('git tag v1.2.0');
+  shell.exec('git checkout master');
+  shell.exec('git branch -D delete-me');
+
+  gitSemverTags(function(err, tags) {
+    equal(tags, ['v1.2.0', 'v1.1.0']);
+
+    done();
+  });
+});


### PR DESCRIPTION
we should still find semver git tags that point to branches (addresses https://github.com/conventional-changelog/standard-version/issues/123, https://github.com/conventional-changelog/standard-version/issues/126)

We should also make sure that we always sort chronologically, addressed by `--date-order`.

I've tested this functionality thoroughly [here](https://github.com/CHANGELOG-bot/debug-standard-version) and have been unable to recreate the issues that I was running into.

CC: @Tapppi, @stevemao 
