### PR TITLE
feat: introducing support for lerna style tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ npm install --save git-semver-tags
 ## Usage
 
 ```js
-var gitSemverTags = require('git-semver-tags');
+var gitSemverTags = require('git-semver-tags', [options]);
 
 gitSemverTags(function(err, tag) {
   console.log(tag);
@@ -30,6 +30,12 @@ v2.0.0
 v1.0.0
 ```
 
+## Options
+
+* `opts.lernaTags`: extract lerna style tags (`foo-package@2.0.0`) from the
+  git history, rather than `v1.0.0` format.
+* `opts.package`: what package should lerna style tags be listed for, e.g.,
+  `foo-package`.
 
 ## License
 

--- a/cli.js
+++ b/cli.js
@@ -3,12 +3,22 @@
 var meow = require('meow');
 var gitSemverTags = require('./');
 
-meow({
+var args = meow({
   help: [
     'Usage',
-    '  git-semver-tags'
+    '  git-semver-tags',
+    'Options',
+    ' --lerna, -l parse lerna style git tags',
+    ' --package, -p when listing lerna style tags, filter by a package'
   ]
 });
+
+// the package argument only makes sense
+// when used in the context of lerna-style git-tags.
+if (args.flags.package && !args.flags.lerna) {
+  console.error('--package should only be used when running in --lerna mode');
+  process.exit(1);
+}
 
 gitSemverTags(function(err, tags) {
   if (err) {
@@ -17,4 +27,7 @@ gitSemverTags(function(err, tags) {
   }
 
   console.log(tags.join('\n'));
+}, {
+  lernaTags: args.flags.lerna,
+  package: args.flags.package
 });

--- a/index.js
+++ b/index.js
@@ -4,7 +4,17 @@ var semverValid = require('semver').valid;
 var regex = /tag:\s*(.+?)[,\)]/gi;
 var cmd = 'git log --decorate --no-color';
 
-module.exports = function(callback) {
+function lernaTag(tag, pkg) {
+  if (pkg && !(new RegExp('^' + pkg + '@')).test(tag)) {
+    return false;
+  } else {
+    return /^.+@[0-9]+\.[0-9]\.[0-9](-.+)?$/.test(tag);
+  }
+}
+
+module.exports = function(callback, opts) {
+  opts = opts || {};
+
   exec(cmd, {
     maxBuffer: Infinity
   }, function(err, data) {
@@ -19,7 +29,11 @@ module.exports = function(callback) {
       var match;
       while (match = regex.exec(decorations)) {
         var tag = match[1];
-        if (semverValid(tag)) {
+        if (opts.lernaTags) {
+          if (lernaTag(tag, opts.package)) {
+            tags.push(tag);
+          }
+        } else if (semverValid(tag)) {
           tags.push(tag);
         }
       }

--- a/test.js
+++ b/test.js
@@ -113,3 +113,27 @@ it('should work with empty commit', function(done) {
     done();
   });
 });
+
+it('should work with lerna style tags', function(done) {
+  writeFileSync('test5', '');
+  shell.exec('git add --all && git commit -m"sixth commit"');
+  shell.exec('git tag foo-project@4.0.0');
+  shell.exec('git add --all && git commit -m"seventh commit"');
+  shell.exec('git tag foo-project@5.0.0');
+
+  gitSemverTags(function(err, tags) {
+    equal(tags, ['foo-project@5.0.0', 'foo-project@4.0.0']);
+    done();
+  }, {lernaTags: true});
+});
+
+it('should allow lerna style tags to be filtered by package', function(done) {
+  writeFileSync('test5', '');
+  shell.exec('git add --all && git commit -m"seventh commit"');
+  shell.exec('git tag bar-project@5.0.0');
+
+  gitSemverTags(function(err, tags) {
+    equal(tags, ['bar-project@5.0.0']);
+    done();
+  }, {lernaTags: true, package: 'bar-project'});
+});


### PR DESCRIPTION
I love using [conventional-changelog](https://github.com/bcoe/conventional-changelog-standard/blob/master/convention.md) on most of my OSS projects for CHANGELOG generation. I would like to continue using the `conventional-changelog` suite of tools, while moving some of my other OSS projects (specifically Istanbul) over to a mono-repo.

As a first step to facilitating this goal, I've added support for the lerna tag format `my-package@0.0.0` to `git-semver-tags`. It's my plan to follow this up with corresponding support in `conventional-changelog-core`.

A couple questions for you @hzoo:

1. can I count on the lerna tag format remaining fairly consistent.
2. how hard would it be to add this functionality to lerna itself (my goal is to eventually run the conventional-changelog tool for each package managed by lerna):
  - is there a convention for writing addons to lerna that could facilitate this.
  - would it make sense to add this support to lerna itself?